### PR TITLE
Add Ansible role for nDPI

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -54,6 +54,16 @@ To diagnose firewall settings, use the provided script:
 ./diag_firewall.sh
 ```
 
+## nDPI Setup
+
+nDPI is installed automatically by the Ansible playbook. Ensure the
+`ndpi` role is listed in `site.yml` and run the playbook against your
+hosts:
+
+```bash
+ansible-playbook -i inventory/hosts site.yml
+```
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/ansible-firewall/group_vars/all.yml
+++ b/ansible-firewall/group_vars/all.yml
@@ -1,1 +1,4 @@
-all:\n  vars:\n    ansible_python_interpreter: /usr/bin/python3
+---
+ansible_python_interpreter: /usr/bin/python3
+ansible_shell_executable: /bin/bash
+ndpi_interface: ndpi0

--- a/ansible-firewall/roles/ndpi/handlers/main.yml
+++ b/ansible-firewall/roles/ndpi/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Apply netplan
+  ansible.builtin.command: netplan apply
+
+- name: Restart networking
+  ansible.builtin.service:
+    name: networking
+    state: restarted
+
+- name: ldconfig
+  ansible.builtin.command: ldconfig

--- a/ansible-firewall/roles/ndpi/tasks/main.yml
+++ b/ansible-firewall/roles/ndpi/tasks/main.yml
@@ -1,0 +1,83 @@
+---
+# Install nDPI and configure the capture interface
+
+- name: Install nDPI dependencies on Debian/Ubuntu
+  ansible.builtin.apt:
+    name:
+      - build-essential
+      - libpcap-dev
+      - git
+      - cmake
+      - libtool
+      - pkg-config
+      - autoconf
+      - automake
+    state: present
+    update_cache: yes
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: Install nDPI dependencies on RedHat
+  ansible.builtin.yum:
+    name:
+      - gcc
+      - gcc-c++
+      - make
+      - libpcap-devel
+      - git
+      - cmake
+      - libtool
+      - pkgconfig
+      - autoconf
+      - automake
+    state: present
+  when: ansible_facts['os_family'] == 'RedHat'
+
+- name: Configure nDPI interface via netplan (Ubuntu)
+  ansible.builtin.template:
+    src: ndpi_netplan.yaml.j2
+    dest: /etc/netplan/99-ndpi.yaml
+    owner: root
+    group: root
+    mode: "0644"
+  vars:
+    iface: "{{ ndpi_interface | default('ndpi0') }}"
+  notify: Apply netplan
+  when: ansible_facts['distribution'] == 'Ubuntu'
+
+- name: Configure nDPI interface via /etc/network/interfaces (Debian)
+  ansible.builtin.blockinfile:
+    path: /etc/network/interfaces
+    block: |
+      # nDPI interface
+      allow-hotplug {{ ndpi_interface | default('ndpi0') }}
+      iface {{ ndpi_interface | default('ndpi0') }} inet dhcp
+    create: yes
+  notify: Restart networking
+  when: ansible_facts['distribution'] == 'Debian'
+
+- name: Configure nDPI interface via NetworkManager (RedHat)
+  ansible.builtin.command: >-
+    nmcli connection add type ethernet ifname {{ ndpi_interface | default('ndpi0') }}
+    con-name {{ ndpi_interface | default('ndpi0') }} autoconnect yes
+  args:
+    creates: "/etc/NetworkManager/system-connections/{{ ndpi_interface | default('ndpi0') }}.nmconnection"
+  when: ansible_facts['os_family'] == 'RedHat'
+
+- name: Clone nDPI repository
+  ansible.builtin.git:
+    repo: https://github.com/ntop/nDPI.git
+    dest: /usr/local/src/nDPI
+    version: master
+
+- name: Build nDPI
+  ansible.builtin.shell: |
+    ./autogen.sh && ./configure && make -j$(nproc)
+  args:
+    chdir: /usr/local/src/nDPI
+
+- name: Install nDPI
+  ansible.builtin.shell: make install
+  args:
+    chdir: /usr/local/src/nDPI
+  notify: ldconfig
+

--- a/ansible-firewall/roles/ndpi/templates/ndpi_netplan.yaml.j2
+++ b/ansible-firewall/roles/ndpi/templates/ndpi_netplan.yaml.j2
@@ -1,0 +1,6 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    {{ iface }}:
+      dhcp4: true

--- a/ansible-firewall/site.yml
+++ b/ansible-firewall/site.yml
@@ -1,5 +1,6 @@
 
-- name: Configure Ubuntu firewall with nftables
+- name: Configure firewall and nDPI
   hosts: all
   roles:
-    - firewall       
+    - firewall
+    - ndpi


### PR DESCRIPTION
## Summary
- replace shell-based nDPI installer with new `ndpi` Ansible role
- configure `ndpi_interface` in `group_vars/all.yml`
- update playbook to include the role
- document nDPI installation in README

## Testing
- `ansible-playbook --syntax-check ansible-firewall/site.yml`


------
https://chatgpt.com/codex/tasks/task_e_6845a607847c83249003a66584847d73