### PR TITLE
Add nDPI based DSCP tagging

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -64,6 +64,11 @@ hosts:
 ansible-playbook -i inventory/hosts site.yml
 ```
 
+The role also deploys a small helper service that feeds nDPI flow
+information into nftables ipsets. These ipsets are then referenced in the
+nftables configuration to apply DSCP marks based on the detected
+application traffic.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/ansible-firewall/group_vars/firewalls.yml
+++ b/ansible-firewall/group_vars/firewalls.yml
@@ -57,20 +57,39 @@ firewall_cfg:
     voice:
       mark: cs6
       match:
+        ndpi_sets:
+          - ndpi:app:zoom
+          - ndpi:app:microsoft-teams
+          - ndpi:category:voip
+          - ndpi:category:vpn
         udp_ports: [53, 5353, 853]            # DNS / DoT / mDNS
 
     gaming:
       mark: af31
       match:
+        ndpi_sets: [ndpi:app:riot-games]
         udp_ports: "5000-5500,8393-8400"
 
     streaming:
       mark: af11
       match:
+        ndpi_sets:
+          - ndpi:app:netflix
+          - ndpi:app:youtube
+          - ndpi:app:amazon-prime-video
+          - ndpi:category:video-streaming
+          - ndpi:app:steam
+          - ndpi:app:xbox-live
+          - ndpi:app:ubisoft-connect
+          - ndpi:app:gog-galaxy
+          - ndpi:category:file-transfer
+          - ndpi:app:windows-update
+          - ndpi:category:software-update
         
     torrent:
       mark: cs1
       match:
+        ndpi_sets: [ndpi:app:bittorrent]
         tcp_ports: "6881-6999,1337,6960-6969"
         udp_ports: "6881-6999,1337,6960-6969"
 

--- a/ansible-firewall/group_vars/rpi4.yml
+++ b/ansible-firewall/group_vars/rpi4.yml
@@ -57,20 +57,39 @@ firewall_cfg:
     voice:
       mark: cs6
       match:
+        ndpi_sets:
+          - ndpi:app:zoom
+          - ndpi:app:microsoft-teams
+          - ndpi:category:voip
+          - ndpi:category:vpn
         udp_ports: [53, 5353, 853]            # DNS / DoT / mDNS
 
     gaming:
       mark: af31
       match:
+        ndpi_sets: [ndpi:app:riot-games]
         udp_ports: "5000-5500,8393-8400"
 
     streaming:
       mark: af11
       match:
+        ndpi_sets:
+          - ndpi:app:netflix
+          - ndpi:app:youtube
+          - ndpi:app:amazon-prime-video
+          - ndpi:category:video-streaming
+          - ndpi:app:steam
+          - ndpi:app:xbox-live
+          - ndpi:app:ubisoft-connect
+          - ndpi:app:gog-galaxy
+          - ndpi:category:file-transfer
+          - ndpi:app:windows-update
+          - ndpi:category:software-update
         
     torrent:
       mark: cs1
       match:
+        ndpi_sets: [ndpi:app:bittorrent]
         tcp_ports: "6881-6999,1337,6960-6969"
         udp_ports: "6881-6999,1337,6960-6969"
 

--- a/ansible-firewall/roles/firewall/tasks/ipsets.yml
+++ b/ansible-firewall/roles/firewall/tasks/ipsets.yml
@@ -1,16 +1,23 @@
 ###############################################################################
 # Ensure that all ipsets referenced in dscp_rules exist (even if empty)
 ###############################################################################
-- set_fact:
-    ipset_names: "{{ dscp_rules | regex_findall('@([A-Za-z0-9_]+)') }}"
-
 - name: Extract ipset names from dscp_rules
   set_fact:
     ipset_names: "{{ dscp_rules | regex_findall('@\"([^\"]+)\"') | list }}"
 
+- name: Gather ipset names from dscp_classes
+  set_fact:
+    ipset_names: "{{ ipset_names + (item.match.ndpi_sets | default([])) + (item.match.netify_sets | default([])) }}"
+  loop: "{{ firewall_cfg.dscp_classes.values() }}"
+  when: firewall_cfg.dscp_classes is defined
+
+- name: Deduplicate ipset names
+  set_fact:
+    ipset_names: "{{ ipset_names | unique }}"
+
 - name: Create required ipsets
   ansible.builtin.command: >
-    ipset create "{{ item }}" hash:ip family inet timeout 0 -exist
+    ipset create "{{ item | regex_replace('[:\\.-]', '_') }}" hash:ip family inet timeout 0 -exist
   loop: "{{ ipset_names }}"
   register: ipset_create
   changed_when: "'created' in ipset_create.stdout"

--- a/ansible-firewall/roles/firewall/templates/nftables.conf.j2
+++ b/ansible-firewall/roles/firewall/templates/nftables.conf.j2
@@ -68,6 +68,9 @@ table inet mangle {
 {%   for ns in (cls.match.netify_sets | default([])) %}
 {%     set _ = ns_names.append(sanitize(ns)) %}
 {%   endfor %}
+{%   for ns in (cls.match.ndpi_sets | default([])) %}
+{%     set _ = ns_names.append(sanitize(ns)) %}
+{%   endfor %}
 {% endfor %}
 {% for ns in ns_names | unique %}
   set {{ ns }} { type ipv4_addr; }
@@ -80,6 +83,11 @@ table inet mangle {
 {%   if cls.match.netify_sets is defined %}
 {%     for ns in cls.match.netify_sets %}
     ip saddr @{{ sanitize(ns) }} ip dscp cs0 counter ip dscp set {{ mark }} comment "{{ name }} netify-saddr";
+{%     endfor %}
+{%   endif %}
+{%   if cls.match.ndpi_sets is defined %}
+{%     for ns in cls.match.ndpi_sets %}
+    ip saddr @{{ sanitize(ns) }} ip dscp cs0 counter ip dscp set {{ mark }} comment "{{ name }} ndpi-saddr";
 {%     endfor %}
 {%   endif %}
 {%   if cls.match is defined and cls.match.udp_ports is defined %}

--- a/ansible-firewall/roles/ndpi/files/ndpi_ipset.py
+++ b/ansible-firewall/roles/ndpi/files/ndpi_ipset.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import sys
+import json
+import subprocess
+
+# Mapping of nDPI application/category names to ipset names
+NDPI_MAP = {
+    "Zoom": "ndpi_app_zoom",
+    "Microsoft Teams": "ndpi_app_microsoft_teams",
+    "VoIP": "ndpi_category_voip",
+    "VPN": "ndpi_category_vpn",
+    "Riot Games": "ndpi_app_riot_games",
+    "YouTube": "ndpi_app_youtube",
+    "Netflix": "ndpi_app_netflix",
+    "Amazon Prime Video": "ndpi_app_amazon_prime_video",
+    "BitTorrent": "ndpi_app_bittorrent",
+}
+
+TIMEOUT = "300"
+
+for line in sys.stdin:
+    try:
+        data = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    app = data.get("master") or data.get("app_protocol")
+    category = data.get("category")
+    src = data.get("src_ip")
+    dst = data.get("dst_ip")
+
+    for name, ipset in NDPI_MAP.items():
+        if app == name or category == name:
+            for ip in (src, dst):
+                if not ip:
+                    continue
+                subprocess.run([
+                    "ipset", "add", ipset, ip, "timeout", TIMEOUT
+                ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            break

--- a/ansible-firewall/roles/ndpi/handlers/main.yml
+++ b/ansible-firewall/roles/ndpi/handlers/main.yml
@@ -9,3 +9,6 @@
 
 - name: ldconfig
   ansible.builtin.command: ldconfig
+
+- name: Reload systemd
+  ansible.builtin.command: systemctl daemon-reload

--- a/ansible-firewall/roles/ndpi/tasks/main.yml
+++ b/ansible-firewall/roles/ndpi/tasks/main.yml
@@ -81,3 +81,24 @@
     chdir: /usr/local/src/nDPI
   notify: ldconfig
 
+- name: Install nDPI ipset helper script
+  ansible.builtin.copy:
+    src: ndpi_ipset.py
+    dest: /usr/local/bin/ndpi_ipset.py
+    mode: '0755'
+
+- name: Install nDPI ipset service
+  ansible.builtin.template:
+    src: ndpi-ipset.service.j2
+    dest: /etc/systemd/system/ndpi-ipset.service
+    mode: '0644'
+  vars:
+    interface: "{{ firewall_cfg.interfaces.wan.nic }}"
+  notify: Reload systemd
+
+- name: Enable and start nDPI ipset service
+  ansible.builtin.systemd:
+    name: ndpi-ipset.service
+    enabled: yes
+    state: started
+

--- a/ansible-firewall/roles/ndpi/templates/ndpi-ipset.service.j2
+++ b/ansible-firewall/roles/ndpi/templates/ndpi-ipset.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=nDPI ipset classification
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/ndpiReader -i {{ interface }} -v 1 -j | /usr/local/bin/ndpi_ipset.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- install helper service to feed nDPI flow info into ipsets
- use ipsets from nDPI in firewall DSCP classes
- update nftables template to handle ndpi ipsets
- extend ipset task logic for new sets
- document the helper service in README

## Testing
- `ansible-playbook --syntax-check ansible-firewall/site.yml`
- `python3 -m py_compile ansible-firewall/roles/ndpi/files/ndpi_ipset.py`


------
https://chatgpt.com/codex/tasks/task_e_6845c0163c648324b9875e6f6ad18991