### PR TITLE
Remove netifyd handler

### DIFF
--- a/ansible-firewall/roles/firewall/handlers/main.yml
+++ b/ansible-firewall/roles/firewall/handlers/main.yml
@@ -15,7 +15,3 @@
   ansible.builtin.command: nft -f /etc/nftables.conf
   become: yes
 
-- name: Restart netifyd
-  ansible.builtin.systemd:
-    name: netifyd
-    state: restarted

--- a/ansible-firewall/roles/firewall/tasks/install.yml
+++ b/ansible-firewall/roles/firewall/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
 # roles/firewall/tasks/install.yml
-# Installs nftables, ipset and Netify – updates cache only when required
+# Installs nftables and ipset – updates cache only when required
 ###############################################################################
 
 # 1 ▸ Core packages -----------------------------------------------------------

--- a/ansible-firewall/roles/firewall/tasks/main.yml
+++ b/ansible-firewall/roles/firewall/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # 0 ▸ System prerequisites
-- import_tasks: install.yml        # packages + Netify
+- import_tasks: install.yml        # packages
 
 # 1 ▸ Kernel settings  (NAT needs forwarding)
 - import_tasks: sysctl.yml         # ← new
@@ -18,7 +18,7 @@
     validate: "nft -c -f %s"
   register: nft_cfg
 
-- import_tasks: ipsets.yml         # auto-create @"netify:*" sets
+- import_tasks: ipsets.yml         # auto-create ipsets
 
 - name: Reload nftables rules
   ansible.builtin.command: nft -f /etc/nftables.conf


### PR DESCRIPTION
## Summary
- remove unused netifyd handler
- clean up references to Netify in firewall tasks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845c26e5d3c8324adf24574d7e23be9